### PR TITLE
Add gitlab image for habitica for performance.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ test-integration:
 	docker-compose build
 	docker-compose run --rm integration
 
+test-images:
+	docker build -t registry.gitlab.com/8mobius8/go-habits/api -f integration/Dockerfile-habitica .
+	docker push registry.gitlab.com/8mobius8/go-habits/api 
+
 build:
 	go build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,7 @@ services:
       - habitica
 
   habitica:
-    build:
-      context: .
-      dockerfile: integration/Dockerfile-habitica
+    image: registry.gitlab.com/8mobius8/go-habits/api
     ports:
       - "3000:3000"
     environment:

--- a/integration/wait-for-habitica-api.sh
+++ b/integration/wait-for-habitica-api.sh
@@ -4,14 +4,17 @@ set -e
 
 cmd="$@"
 date_to_wait_until=$(date -d "+1mins" +%s)
-until go-habits isup; do
-  >&2 echo "Habitica API is down at $SERVER"
+echo "Waiting Habitica API to be up"
+until go-habits isup > /dev/null 2>&1; do
+  >&2 printf "."
   sleep 1
   if [ $date_to_wait_until  -lt $(date +%s) ]; then
+    echo
     echo "Habitica API took too long to start"
     exit 0
   fi
 done
 
+echo
 >&2 echo "Habitica API is up at starting running '$cmd'"
 exec $cmd


### PR DESCRIPTION
From ~7 to ~3mins. This is for latest develop branch of habitica. Should probably be able to pick a version of habitica to test against eventually.

<img width="868" alt="screen shot 2018-09-04 at 18 17 15" src="https://user-images.githubusercontent.com/2933379/45065577-d3bbee00-b06e-11e8-883b-e9abf70185e2.png">
